### PR TITLE
Hide Live Site buttons in portfolio until projects are ready

### DIFF
--- a/script.js
+++ b/script.js
@@ -2387,11 +2387,8 @@ function createProjectCard(project) {
     const statusClass = project.status === 'active' ? 'status-active' : 'status-development';
     const statusText = project.status === 'active' ? 'Live' : 'In Development';
     
-    const liveLink = project.liveUrl ? 
-        `<a href="${project.liveUrl}" target="_blank" rel="noopener noreferrer" class="project-link">
-            <span>🌐</span> Live Site
-        </a>` : 
-        `<span class="project-link disabled">
+    // Hide live site buttons until projects are ready for public access
+    const liveLink = `<span class="project-link disabled">
             <span>🌐</span> Coming Soon
         </span>`;
     


### PR DESCRIPTION
## Summary
- Hide all Live Site buttons in portfolio section until projects are ready for public access
- All projects now show 'Coming Soon' instead of live site links
- GitHub repository links remain active for code review and technical demonstration
- Maintains professional presentation while projects are in development phase

## Changes Made
- Modified portfolio JavaScript to show 'Coming Soon' for all projects
- Easy to restore when ready to make projects publicly accessible
- No visual design changes, only button functionality

## Test Plan
- ✅ Verify all portfolio projects show 'Coming Soon' instead of live links
- ✅ Confirm GitHub links remain active and functional
- ✅ Check responsive design maintains proper button styling

Small change to maintain professional presentation while projects are in development.

🤖 Generated with [Claude Code](https://claude.ai/code)